### PR TITLE
Feature: user crud

### DIFF
--- a/src/main/java/com/mandacarubroker/controller/UserController.java
+++ b/src/main/java/com/mandacarubroker/controller/UserController.java
@@ -2,7 +2,6 @@ package com.mandacarubroker.controller;
 
 import com.mandacarubroker.domain.user.RequestUserDTO;
 import com.mandacarubroker.domain.user.ResponseUserDTO;
-import com.mandacarubroker.domain.user.User;
 import com.mandacarubroker.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
@@ -20,12 +19,12 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping
-    public ResponseEntity<List<User>> getAllUsers() {
+    public ResponseEntity<List<ResponseUserDTO>> getAllUsers() {
         return ResponseEntity.ok(userService.getAllUsers());
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<User> getUserById(@PathVariable String id) {
+    public ResponseEntity<ResponseUserDTO> getUserById(@PathVariable String id) {
         return ResponseEntity.ok(userService.getUserById(id));
     }
 

--- a/src/main/java/com/mandacarubroker/controller/UserController.java
+++ b/src/main/java/com/mandacarubroker/controller/UserController.java
@@ -1,0 +1,50 @@
+package com.mandacarubroker.controller;
+
+import com.mandacarubroker.domain.user.RequestUserDTO;
+import com.mandacarubroker.domain.user.ResponseUserDTO;
+import com.mandacarubroker.domain.user.User;
+import com.mandacarubroker.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users")
+public class UserController {
+    
+    private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<List<User>> getAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUserById(@PathVariable String id) {
+        return ResponseEntity.ok(userService.getUserById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<ResponseUserDTO> createUser(@RequestBody RequestUserDTO data, HttpServletRequest http) {
+        ResponseUserDTO createdUser = userService.createUser(data);
+        URI uri = UriComponentsBuilder.fromUriString(http.getRequestURI()).path("/{id}").buildAndExpand(createdUser.id()).toUri();
+        return ResponseEntity.created(uri).body(createdUser);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ResponseUserDTO> updateUser(@PathVariable String id, @RequestBody RequestUserDTO updatedUser) {
+        return ResponseEntity.ok(userService.updateUser(id, updatedUser));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable String id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+    
+}

--- a/src/main/java/com/mandacarubroker/controller/exceptions/ResourceExceptionHandler.java
+++ b/src/main/java/com/mandacarubroker/controller/exceptions/ResourceExceptionHandler.java
@@ -1,20 +1,33 @@
 package com.mandacarubroker.controller.exceptions;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import java.time.Instant;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+
 @RestControllerAdvice
 public class ResourceExceptionHandler {
+
+    private final HttpServletRequest http;
+
+    public ResourceExceptionHandler(HttpServletRequest http) {
+        this.http = http;
+    }
+
     @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<String> entityNotFound(EntityNotFoundException exception){
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+    public ResponseEntity<StandardError> entityNotFound(EntityNotFoundException exception){
+        StandardError error = new StandardError(Instant.now(),HttpStatus.NOT_FOUND.value(),"Entity Not Found",exception.getMessage(),http.getRequestURI());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
     }
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<String> validationException(ConstraintViolationException exc){
-        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(exc.getMessage());
+    public ResponseEntity<StandardError> validationException(ConstraintViolationException exc){
+        StandardError error = new StandardError(Instant.now(),HttpStatus.UNPROCESSABLE_ENTITY.value(),
+                "Validation Exception",exc.getMessage(),http.getRequestURI());
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(error);
     }
 }

--- a/src/main/java/com/mandacarubroker/controller/exceptions/StandardError.java
+++ b/src/main/java/com/mandacarubroker/controller/exceptions/StandardError.java
@@ -1,0 +1,6 @@
+package com.mandacarubroker.controller.exceptions;
+
+import java.time.Instant;
+
+public record StandardError(Instant instant, Integer status, String error, String message, String path) {
+}

--- a/src/main/java/com/mandacarubroker/domain/stock/Stock.java
+++ b/src/main/java/com/mandacarubroker/domain/stock/Stock.java
@@ -10,7 +10,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-@Table(name ="stock")
+@Table(name ="tb_stock")
 @Entity(name="stock")
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/mandacarubroker/domain/user/RequestUserDTO.java
+++ b/src/main/java/com/mandacarubroker/domain/user/RequestUserDTO.java
@@ -1,0 +1,13 @@
+package com.mandacarubroker.domain.user;
+
+import java.time.LocalDate;
+
+public record RequestUserDTO(
+        String username,
+        String password,
+        String email,
+        String firstName,
+        String lastName,
+        LocalDate birthDate,
+        Double balance
+) { }

--- a/src/main/java/com/mandacarubroker/domain/user/ResponseUserDTO.java
+++ b/src/main/java/com/mandacarubroker/domain/user/ResponseUserDTO.java
@@ -1,0 +1,17 @@
+package com.mandacarubroker.domain.user;
+
+import java.time.LocalDate;
+
+public record ResponseUserDTO (
+        String id,
+        String username,
+        String email,
+        String firstName,
+        String lastName,
+        LocalDate birthDate,
+        Double balance
+){
+    public ResponseUserDTO(User user){
+        this(user.getId(), user.getUsername(),user.getEmail(), user.getFirstName(), user.getLastName(), user.getBirthDate(), user.getBalance());
+    }
+}

--- a/src/main/java/com/mandacarubroker/domain/user/User.java
+++ b/src/main/java/com/mandacarubroker/domain/user/User.java
@@ -1,0 +1,42 @@
+package com.mandacarubroker.domain.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "user")
+@Table(name = "tb_user")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of="id")
+public class User {
+
+    @Id @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+    private String username;
+    private String password;
+    private String email;
+    private String firstName;
+    private String lastName;
+    private LocalDate birthDate;
+    private Double balance;
+
+    public User(RequestUserDTO dto){
+        setUsername(dto.username());
+        setPassword(dto.password());
+        setEmail(dto.email());
+        setFirstName(dto.firstName());
+        setLastName(dto.lastName());
+        setBirthDate(dto.birthDate());
+        setBalance(dto.balance());
+    }
+
+}

--- a/src/main/java/com/mandacarubroker/domain/user/UserRepository.java
+++ b/src/main/java/com/mandacarubroker/domain/user/UserRepository.java
@@ -1,0 +1,6 @@
+package com.mandacarubroker.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User,String>{
+}

--- a/src/main/java/com/mandacarubroker/service/UserService.java
+++ b/src/main/java/com/mandacarubroker/service/UserService.java
@@ -16,12 +16,14 @@ public class UserService {
     private final UserRepository userRepository;
     private static final String NOT_FOUND_MSG = "User Not Found";
     
-    public List<User> getAllUsers() {
-        return userRepository.findAll();
+    public List<ResponseUserDTO> getAllUsers() {
+        return userRepository.findAll()
+                .stream().map(ResponseUserDTO::new).toList();
     }
 
-    public User getUserById(String id) {
-        return userRepository.findById(id).orElseThrow(()->new EntityNotFoundException(NOT_FOUND_MSG));
+    public ResponseUserDTO getUserById(String id) {
+        return userRepository.findById(id).map(ResponseUserDTO::new)
+                .orElseThrow(()->new EntityNotFoundException(NOT_FOUND_MSG));
     }
 
     public ResponseUserDTO createUser(RequestUserDTO data) {

--- a/src/main/java/com/mandacarubroker/service/UserService.java
+++ b/src/main/java/com/mandacarubroker/service/UserService.java
@@ -1,0 +1,59 @@
+package com.mandacarubroker.service;
+
+import com.mandacarubroker.domain.user.RequestUserDTO;
+import com.mandacarubroker.domain.user.ResponseUserDTO;
+import com.mandacarubroker.domain.user.User;
+import com.mandacarubroker.domain.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+    
+    private final UserRepository userRepository;
+    private static final String NOT_FOUND_MSG = "User Not Found";
+    
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    public User getUserById(String id) {
+        return userRepository.findById(id).orElseThrow(()->new EntityNotFoundException(NOT_FOUND_MSG));
+    }
+
+    public ResponseUserDTO createUser(RequestUserDTO data) {
+        validateRequestUserDTO(data);
+        User newUser = new User(data);
+        return new ResponseUserDTO(userRepository.save(newUser));
+    }
+
+    private void validateRequestUserDTO(RequestUserDTO data) {
+        //validation method
+    }
+
+    public ResponseUserDTO updateUser(String id, RequestUserDTO updatedUser) {
+        validateRequestUserDTO(updatedUser);
+        User updatedUserEntity = userRepository.findById(id)
+                .map(user -> {
+                    user.setUsername(updatedUser.username());
+                    user.setPassword(updatedUser.password());
+                    user.setEmail(updatedUser.email());
+                    user.setFirstName(updatedUser.firstName());
+                    user.setLastName(updatedUser.lastName());
+                    user.setBirthDate(updatedUser.birthDate());
+                    user.setBalance(updatedUser.balance());
+                     return userRepository.save(user);
+                }).orElseThrow(()->new EntityNotFoundException(NOT_FOUND_MSG));
+        return new ResponseUserDTO(updatedUserEntity);
+    }
+
+    public void deleteUser(String id) {
+        if (!userRepository.existsById(id)){
+            throw new EntityNotFoundException(NOT_FOUND_MSG);
+        }
+        userRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/db/migration/V1__create-table-stock.sql
+++ b/src/main/resources/db/migration/V1__create-table-stock.sql
@@ -1,6 +1,16 @@
-CREATE TABLE stock(
+CREATE TABLE tb_stock(
                       id VARCHAR PRIMARY KEY,
                       symbol VARCHAR NOT NULL,
                       company_name VARCHAR NOT NULL,
                       price FLOAT NOT NULL
+);
+CREATE TABLE tb_user(
+                        id VARCHAR PRIMARY KEY,
+                        username VARCHAR NOT NULL UNIQUE ,
+                        password VARCHAR NOT NULL,
+                        email VARCHAR NOT NULL UNIQUE ,
+                        first_name VARCHAR NOT NULL,
+                        last_name VARCHAR NOT NULL,
+                        birth_date DATE NOT NULL,
+                        balance FLOAT NOT NULL
 );

--- a/src/test/java/com/mandacarubroker/MandacarubrokerApplicationTests.java
+++ b/src/test/java/com/mandacarubroker/MandacarubrokerApplicationTests.java
@@ -4,7 +4,6 @@ import com.mandacarubroker.controller.StockController;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest

--- a/src/test/java/com/mandacarubroker/controller/StockControllerIT.java
+++ b/src/test/java/com/mandacarubroker/controller/StockControllerIT.java
@@ -34,14 +34,14 @@ class StockControllerIT {
     @Autowired
     private StockRepository stockRepository;
     private Stock stock;
-    private int totalStocks;
+    private Long totalStocks;
     private String existingId;
 
     @BeforeEach
     void setup(){
         stock= new Stock("1","ABC1","ABC COMPANY",50.0);
         Stock savedStock = stockRepository.save(stock);
-        totalStocks=11;
+        totalStocks=stockRepository.count();
         existingId = savedStock.getId();
     }
     @Test

--- a/src/test/java/com/mandacarubroker/controller/UserControllerTest.java
+++ b/src/test/java/com/mandacarubroker/controller/UserControllerTest.java
@@ -1,0 +1,151 @@
+package com.mandacarubroker.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mandacarubroker.controller.exceptions.StandardError;
+import com.mandacarubroker.domain.user.RequestUserDTO;
+import com.mandacarubroker.domain.user.ResponseUserDTO;
+import com.mandacarubroker.domain.user.User;
+import com.mandacarubroker.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private UserService userService;
+    @Autowired
+    private ObjectMapper objectMapper;
+    private RequestUserDTO validRequestUserDto;
+    private ResponseUserDTO validResponseUserDto;
+    private String existingId,nonExistingId;
+    private static final String USERS_URL = "/users";
+    private static final String NOT_FOUND_MSG = "User Not Found";
+    private StandardError errorNotFound;
+    @BeforeEach
+    void setup(){
+        User user = new User("1", "peaga", "123456", "peaga@mail.com"
+                , "Paulo", "Herbert", LocalDate.parse("2004-04-05"), 500.0);
+        validRequestUserDto = new RequestUserDTO(user.getUsername(), user.getPassword()
+                , user.getEmail(), user.getFirstName(), user.getLastName(), user.getBirthDate(), user.getBalance());
+        validResponseUserDto = new ResponseUserDTO(user);
+        existingId = "1";
+        nonExistingId = "null";
+
+        errorNotFound = new StandardError(Instant.now(), HttpStatus.NOT_FOUND.value(),"Entity Not Found",NOT_FOUND_MSG,
+                UriComponentsBuilder.fromPath(USERS_URL+"/{id}").buildAndExpand(nonExistingId).toUriString());
+    }
+
+    @Test
+    void getAllStocksShouldReturnStatusOK() throws Exception {
+        when(userService.getAllUsers()).thenReturn(List.of(validResponseUserDto));
+
+        mockMvc.perform(get(USERS_URL).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andExpect(jsonPath("$",hasSize(1)))
+                .andExpect(jsonPath("$[0].id").value(validResponseUserDto.id()))
+                .andExpect(jsonPath("$[0].username").value(validResponseUserDto.username()))
+                .andExpect(jsonPath("$[0].password").doesNotExist());
+    }
+
+    @Test
+    void findByIdShouldReturnStatusOK() throws Exception {
+        when(userService.getUserById(existingId)).thenReturn(validResponseUserDto);
+        mockMvc.perform(get(USERS_URL+"/{id}",existingId).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andExpect(jsonPath("$").exists())
+                .andExpect(jsonPath("$.id").value(validResponseUserDto.id()))
+                .andExpect(jsonPath("$.username").value(validResponseUserDto.username()))
+                .andExpect(jsonPath("$.password").doesNotExist());
+    }
+
+    @Test
+    void findByIdShouldReturnNotFoundStatus() throws Exception {
+        when(userService.getUserById(nonExistingId)).thenThrow(new EntityNotFoundException(NOT_FOUND_MSG));
+        mockMvc.perform(get(USERS_URL+"/{id}",nonExistingId).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.instant").exists())
+                .andExpect(jsonPath("$.status").value(errorNotFound.status()))
+                .andExpect(jsonPath("$.error").value(errorNotFound.error()))
+                .andExpect(jsonPath("$.message").value(errorNotFound.message()))
+                .andExpect(jsonPath("$.path").value(errorNotFound.path()));
+    }
+
+    @Test
+    void createShouldReturnStatusCreated() throws Exception {
+        String jsonObject = objectMapper.writeValueAsString(validRequestUserDto);
+        when(userService.createUser(validRequestUserDto)).thenReturn(validResponseUserDto);
+
+        mockMvc.perform(post(USERS_URL).content(jsonObject).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated()).andExpect(header().stringValues("location","/users/1"))
+                .andExpect(jsonPath("$").exists())
+                .andExpect(jsonPath("$.id").value(validResponseUserDto.id()))
+                .andExpect(jsonPath("$.username").value(validResponseUserDto.username()))
+                .andExpect(jsonPath("$.password").doesNotExist());
+    }
+
+    @Test
+    void updateShouldReturnOKStatus() throws Exception {
+        String jsonObject = objectMapper.writeValueAsString(validRequestUserDto);
+        when(userService.updateUser(existingId,validRequestUserDto)).thenReturn(validResponseUserDto);
+
+        mockMvc.perform(put(USERS_URL+"/{id}",existingId).content(jsonObject).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(existingId))
+                .andExpect(jsonPath("$.username").value(validResponseUserDto.username()))
+                .andExpect(jsonPath("$.password").doesNotExist());
+    }
+
+    @Test
+    void updateShouldReturnNotFoundStatusWhenNonExistingIdAndValidRequest() throws Exception {
+        String jsonObject = objectMapper.writeValueAsString(validRequestUserDto);
+        when(userService.updateUser(nonExistingId,validRequestUserDto)).thenThrow(new EntityNotFoundException(NOT_FOUND_MSG));
+
+        mockMvc.perform(put(USERS_URL+"/{id}",nonExistingId).content(jsonObject).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.instant").exists())
+                .andExpect(jsonPath("$.status").value(errorNotFound.status()))
+                .andExpect(jsonPath("$.error").value(errorNotFound.error()))
+                .andExpect(jsonPath("$.message").value(errorNotFound.message()))
+                .andExpect(jsonPath("$.path").value(errorNotFound.path()));
+    }
+
+    @Test
+    void deleteShouldReturnNoContent() throws Exception {
+        doNothing().when(userService).deleteUser(existingId);
+        mockMvc.perform(delete(USERS_URL+"/{id}",existingId))
+                .andExpect(status().isNoContent())
+                .andExpect(content().string(blankOrNullString()));
+    }
+
+    @Test
+    void deleteShouldReturnNotFoundWhenNonExistingId() throws Exception {
+        doThrow(new EntityNotFoundException(NOT_FOUND_MSG)).when(userService).deleteUser(nonExistingId);
+        mockMvc.perform(delete(USERS_URL+"/{id}",nonExistingId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.instant").exists())
+                .andExpect(jsonPath("$.status").value(errorNotFound.status()))
+                .andExpect(jsonPath("$.error").value(errorNotFound.error()))
+                .andExpect(jsonPath("$.message").value(errorNotFound.message()))
+                .andExpect(jsonPath("$.path").value(errorNotFound.path()));
+    }
+}

--- a/src/test/java/com/mandacarubroker/service/UserServiceTest.java
+++ b/src/test/java/com/mandacarubroker/service/UserServiceTest.java
@@ -1,0 +1,135 @@
+package com.mandacarubroker.service;
+
+import com.mandacarubroker.domain.user.RequestUserDTO;
+import com.mandacarubroker.domain.user.ResponseUserDTO;
+import com.mandacarubroker.domain.user.User;
+import com.mandacarubroker.domain.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class UserServiceTest {
+    
+    @Mock
+    private UserRepository userRepository;
+    @InjectMocks
+    private UserService userService;
+    private User user;
+    private RequestUserDTO validRequestUserDto;
+    private String existingId,nonExistingId;
+    
+    @BeforeEach
+    void setup(){
+        user = new User("1","peaga","123456","peaga@mail.com"
+                ,"Paulo","Herbert", LocalDate.parse("2004-04-05"),500.0);
+        validRequestUserDto = new RequestUserDTO(user.getUsername(), user.getPassword()
+                ,user.getEmail(), user.getFirstName(), user.getLastName(),user.getBirthDate(),user.getBalance());
+        existingId = "1";
+        nonExistingId = "null";
+    }
+
+    @Test
+    void findAllShouldReturnAResponseUserDTOList(){
+        when(userRepository.findAll()).thenReturn(List.of(user));
+        List<ResponseUserDTO> users = userService.getAllUsers();
+        verify(userRepository).findAll();
+        assertFalse(users.isEmpty());
+    }
+
+    @Test
+    void getUserByIdShouldReturnAResponseUserDTOWhenExistingId(){
+        when(userRepository.findById(existingId)).thenReturn(Optional.of(user));
+
+        ResponseUserDTO created = userService.getUserById(existingId);
+
+        verify(userRepository,only()).findById(any());
+        
+        assertNotNull(created);
+        assertEquals(user.getId(),created.id());
+        assertEquals(user.getUsername(),created.username());
+        assertEquals(user.getEmail(),created.email());
+        assertEquals(user.getFirstName(),created.firstName());
+        assertEquals(user.getLastName(),created.lastName());
+        assertEquals(user.getBalance(),created.balance());
+        assertEquals(user.getBirthDate(),created.birthDate());
+    }
+
+    @Test
+    void getUserByIdShouldThrowEntityNotFoundWhenNonExistingId(){
+        when(userRepository.findById(nonExistingId)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class,()->userService.getUserById(nonExistingId));
+        verify(userRepository,only()).findById(any());
+    }
+
+    @Test
+    void createShouldReturnAResponseUserDTO(){
+        when(userRepository.save(any())).thenReturn(user);
+       
+        ResponseUserDTO created = userService.createUser(validRequestUserDto);
+
+        assertNotNull(created);
+        assertNotNull(created.id());
+        assertEquals(validRequestUserDto.username(),created.username());
+        assertEquals(validRequestUserDto.email(),created.email());
+        assertEquals(validRequestUserDto.firstName(),created.firstName());
+        assertEquals(validRequestUserDto.lastName(),created.lastName());
+        assertEquals(validRequestUserDto.balance(),created.balance());
+        assertEquals(validRequestUserDto.birthDate(),created.birthDate());
+
+    }
+
+    @Test
+    void updateShouldReturnAResponseUserDTOWhenExistingId(){
+        when(userRepository.findById(existingId)).thenReturn(Optional.ofNullable(user));
+        when(userRepository.save(any())).thenReturn(user);
+
+        ResponseUserDTO updatedUser = userService.updateUser(existingId,validRequestUserDto);
+
+        assertNotNull(updatedUser);
+        assertNotNull(updatedUser.id());
+        assertEquals(validRequestUserDto.username(),updatedUser.username());
+        assertEquals(validRequestUserDto.email(),updatedUser.email());
+        assertEquals(validRequestUserDto.firstName(),updatedUser.firstName());
+        assertEquals(validRequestUserDto.lastName(),updatedUser.lastName());
+        assertEquals(validRequestUserDto.balance(),updatedUser.balance());
+        assertEquals(validRequestUserDto.birthDate(),updatedUser.birthDate());
+    }
+
+    @Test
+    void updateShouldThrowEntityNotFoundExceptionWhenNonExistingIdAndValidRequestBody(){
+        when(userRepository.findById(nonExistingId)).thenReturn(Optional.empty());
+        
+        assertThrows(EntityNotFoundException.class,()->userService.updateUser(nonExistingId,validRequestUserDto));
+    }
+
+    @Test
+    void deleteShouldDoNothing(){
+        when(userRepository.existsById(existingId)).thenReturn(true);
+        doNothing().when(userRepository).deleteById(anyString());
+
+        assertDoesNotThrow(()->userService.deleteUser(existingId));
+    }
+
+    @Test
+    void deleteShouldThrowEntityNotFoundExceptionWhenNonExistingId(){
+        doReturn(false).when(userRepository).existsById(nonExistingId);
+        assertThrows(EntityNotFoundException.class,()->userService.deleteUser(existingId));
+        verify(userRepository,never()).deleteById(anyString());
+    }
+
+}


### PR DESCRIPTION
Este PR adiciona as funcionalidades de um CRUD para a entidade User
O usuário na aplicação deve ser composto pelos seguintes campos:
+ username
+ password
+ email
+ firstName
+ lastName
+ birthDate (apenas maiores de 18 anos)
+ balance

As funcionalidades podem ser acessadas a partir da rota `/users`. No momento, não é necessário autenticação, segue um exemplo de requisição:
```http
POST /users
```
```json
      {
	"username":"peaga12",
	"password":"12345678",
	"email":"peaga12@mail.com",
	"firstName":"Paulo",
	"lastName":"Herbert",
	"birthDate": "2004-04-05",
	"balance":500
      }
```
As únicas validações são a nível de banco de dados(campos username e email são únicos, não permite repetição)
formato de data "yyyy-MM-dd"
## **Arquivos adicionados:**
RequestUserDTO
ResponseUserDTO (ocultando a visibilidade do campo password)
User, UserRepository
UserService
UserController
StandardError(para padronizar as mensagens de erro)
## **Modificados:**
V1__create-table-stock.sql (adicionado criação da tabela users no flyway migrations)
ResourceExceptionHandler (Ajustado a mensagem de erro retornada em caso de falha nas requisições)
Stock (renomeando nome da tabela)
## **Testes desenvolvidos:**
Foram testados os comportamentos de Create, Update, Read e Delete.
Testes unitários na camada service, validando os casos de sucesso (comportamento esperado) e os casos de falha (exceptions lançadas corretamente)
Testes unitários na camada resource, validando os códigos http corretos, se o corpo da resposta é o esperado para cada método. E os casos de falha, verificando se o corpo da resposta contém a mensagem de erro adequada, além do código http correto.